### PR TITLE
Move info from title to left column and implement multi-select tools to avoid long scrolls

### DIFF
--- a/water/main.py
+++ b/water/main.py
@@ -3,7 +3,7 @@ from bokeh.layouts import row, column
 from bokeh.models.graphs import from_networkx, NodesAndLinkedEdges
 from bokeh.models import (Range1d, MultiLine, Circle, HoverTool, Slider, Span,
                           Button, ColorBar, LogTicker, ColumnDataSource)
-from bokeh.models.widgets import Dropdown, MultiSelect, Div
+from bokeh.models.widgets import Dropdown, MultiSelect, Div, Select
 from bokeh.plotting import figure
 from bokeh.tile_providers import get_provider, Vendors
 from bokeh.transform import log_cmap
@@ -50,7 +50,7 @@ def update_highlights():
         'Tank': 'green'
         })
 
-    injection = pollution_location_dropdown.value
+    injection = pollution_location_select.value
     nodes_to_highlight = pollution_history_multiselect.value
     type_highlight = node_type_dropdown.value
 
@@ -145,7 +145,7 @@ def update_slider(attrname, old, new):
 
 
 def update_injection(attrname, old, new):
-    """Pollution injection node drop down callback.
+    """Pollution injection node location drop down callback.
     The global variable scenario, which holds the dataframe of pollution
     dynamics is updated.
     As the injection site affects both the node highlights and pollution data
@@ -155,7 +155,7 @@ def update_injection(attrname, old, new):
     update_highlights()
     update_pollution_history()
     update()
-    injection_node = pollution_location_dropdown.value
+    injection_node = pollution_location_select.value
     pollution_location_div.text = pollution_loaction_html(injection_node,
                                                           injection_color)
 
@@ -338,14 +338,13 @@ node_type_dropdown = Dropdown(label="Highlight Node Type", value='None',
 node_type_dropdown.on_change('value', update_node_type_highlight)
 
 # Dropdown menu to choose pollution start location
-pollution_location_dropdown = Dropdown(label="Pollution Injection Node",
+pollution_location_select = Select(title="Pollution Injection Node",
                                        value=injection_nodes[0],
-                                       css_classes=['blue_button'],
-                                       menu=injection_nodes)
-pollution_location_dropdown.on_change('value', update_injection)
+                                       options=injection_nodes)
+pollution_location_select.on_change('value', update_injection)
 
 # Create a div to show the name of pollution start node
-injection_node = pollution_location_dropdown.value
+injection_node = pollution_location_select.value
 pol_location_html = pollution_loaction_html(injection_node, injection_color)
 pollution_location_div = Div(text=pol_location_html)
 
@@ -376,7 +375,7 @@ layout = column(
             pollution_history_multiselect,
             pollution_history_node_div,
             node_type_dropdown,
-            pollution_location_dropdown,
+            pollution_location_select,
             pollution_location_div,
             node_size_slider,
             play_button,
@@ -395,7 +394,7 @@ layout = column(
 # Initialise
 callback_id = None
 animation_speed = speeds[speed_dropdown.value]
-scenario = pollution_scenario(pollution, pollution_location_dropdown.value)
+scenario = pollution_scenario(pollution, pollution_location_select.value)
 history = pollution[start_node]['J-10']
 pollution_history_source.data['time'] = history.index
 pollution_history_source.data['pollution_value'] = history.values

--- a/water/main.py
+++ b/water/main.py
@@ -3,7 +3,7 @@ from bokeh.layouts import row, column
 from bokeh.models.graphs import from_networkx, NodesAndLinkedEdges
 from bokeh.models import (Range1d, MultiLine, Circle, HoverTool, Slider, Span,
                           Button, ColorBar, LogTicker, ColumnDataSource)
-from bokeh.models.widgets import Dropdown, MultiSelect, Div, Select
+from bokeh.models.widgets import Dropdown, Div, Select
 from bokeh.plotting import figure
 from bokeh.tile_providers import get_provider, Vendors
 from bokeh.transform import log_cmap
@@ -51,7 +51,7 @@ def update_highlights():
         })
 
     injection = pollution_location_select.value
-    nodes_to_highlight = pollution_history_multiselect.value
+    node_to_highlight = pollution_history_select.value
     type_highlight = node_type_dropdown.value
 
     outline_colors = []
@@ -61,7 +61,7 @@ def update_highlights():
             # Color injection node the injection color regardless of its type
             outline_colors.append(injection_color)
             outline_widths.append(highlight_width)
-        elif node in nodes_to_highlight:
+        elif node == node_to_highlight:
             # Color selected node bright green
             outline_colors.append(highlight_color)
             outline_widths.append(highlight_width)
@@ -79,11 +79,11 @@ def update_highlights():
 
 
 def update_pollution_history():
-    history_node = pollution_history_multiselect.value[0]
+    history_node = pollution_history_select.value
     history = pollution_history(scenario, history_node)
     pollution_history_source.data['time'] = history.index
     pollution_history_source.data['pollution_value'] = history.values
-    if pollution_history_node != 'None':
+    if history_node != 'None':
         pollution_history_plot.x_range.update(start=0,
                                               end=max(history.index))
         pollution_history_plot.y_range.update(start=0,
@@ -125,7 +125,7 @@ def update_node_highlight(attrname, old, new):
     the update highlights function."""
     update_highlights()
     update_pollution_history()
-    history_node = pollution_history_multiselect.value[0]
+    history_node = pollution_history_select.value
     pollution_history_node_div.text = pollution_history_html(history_node,
                                                              highlight_color)
 
@@ -320,10 +320,10 @@ play_button = Button(label=BUTTON_LABEL_PAUSED, button_type="success")
 play_button.on_click(animate)
 
 # Menu to highlight nodes green and display pollution history
-pollution_history_multiselect = MultiSelect(title="Pollution History",
-                                            value=["None"],
-                                            options=['None']+list(G.nodes()))
-pollution_history_multiselect.on_change('value', update_node_highlight)
+pollution_history_select = Select(title="Pollution History",
+                                       value="None",
+                                       options=['None']+list(G.nodes()))
+pollution_history_select.on_change('value', update_node_highlight)
 
 # Create a div to show the name of pollution history node
 pollution_history_node_div = Div(text=pollution_history_html())
@@ -339,8 +339,8 @@ node_type_dropdown.on_change('value', update_node_type_highlight)
 
 # Dropdown menu to choose pollution start location
 pollution_location_select = Select(title="Pollution Injection Node",
-                                       value=injection_nodes[0],
-                                       options=injection_nodes)
+                                   value=injection_nodes[0],
+                                   options=injection_nodes)
 pollution_location_select.on_change('value', update_injection)
 
 # Create a div to show the name of pollution start node
@@ -372,7 +372,7 @@ timer = Div(text="")
 layout = column(
     row(
         column(
-            pollution_history_multiselect,
+            pollution_history_select,
             pollution_history_node_div,
             node_type_dropdown,
             pollution_location_select,

--- a/water/main.py
+++ b/water/main.py
@@ -221,7 +221,7 @@ def plot_bounds(locations):
 
 G, locations, all_base_demands = load_water_network()
 
-(pollution, scenarios, start_node, start_step, end_step, step_size,
+(pollution, pollution_nodes, start_node, start_step, end_step, step_size,
  max_pol, min_pol) = load_pollution_dynamics()
 
 # Create figure object
@@ -335,9 +335,9 @@ node_type_dropdown.on_change('value', update_node_type_highlight)
 
 # Dropdown menu to choose pollution start location
 pollution_location_dropdown = Dropdown(label="Pollution Injection Node",
-                                       value=scenarios[0],
+                                       value=pollution_nodes[0],
                                        css_classes=['blue_button'],
-                                       menu=scenarios)
+                                       menu=pollution_nodes)
 pollution_location_dropdown.on_change('value', update_injection)
 
 # Create a div to show the name of pollution start node

--- a/water/main.py
+++ b/water/main.py
@@ -3,7 +3,7 @@ from bokeh.layouts import row, column
 from bokeh.models.graphs import from_networkx, NodesAndLinkedEdges
 from bokeh.models import (Range1d, MultiLine, Circle, HoverTool, Slider, Span,
                           Button, ColorBar, LogTicker, Title, ColumnDataSource)
-from bokeh.models.widgets import Dropdown
+from bokeh.models.widgets import Dropdown, MultiSelect
 from bokeh.plotting import figure
 from bokeh.tile_providers import get_provider, Vendors
 from bokeh.transform import log_cmap
@@ -49,7 +49,7 @@ def update_highlights():
         })
 
     injection = pollution_location_dropdown.value
-    node_highlight = node_highlight_dropdown.value
+    nodes_to_highlight = node_highlight_multiselect.value
     type_highlight = node_type_dropdown.value
 
     outline_colors = []
@@ -59,7 +59,7 @@ def update_highlights():
             # Color injection node the injection color regardless of its type
             outline_colors.append(injection_color)
             outline_widths.append(highlight_width)
-        elif node == node_highlight:
+        elif node in nodes_to_highlight:
             # Color selected node bright green
             outline_colors.append(highlight_color)
             outline_widths.append(highlight_width)
@@ -77,8 +77,7 @@ def update_highlights():
 
 
 def update_pollution_history():
-    pollution_history_node = node_highlight_dropdown.value
-    history = pollution_history(scenario, pollution_history_node)
+    history = pollution_history(scenario, node_highlight_multiselect.value[0])
     pollution_history_source.data['time'] = history.index
     pollution_history_source.data['pollution_value'] = history.values
     if pollution_history_node != 'None':
@@ -318,11 +317,11 @@ slider.on_change('value', update_slider)
 play_button = Button(label=BUTTON_LABEL_PAUSED, button_type="success")
 play_button.on_click(animate)
 
-# Dropdown menu to highlight a particular node
-node_highlight_dropdown = Dropdown(label="Pollution History", value='None',
-                                   css_classes=['green_button'],
-                                   menu=['None']+list(G.nodes()))
-node_highlight_dropdown.on_change('value', update_node_highlight)
+# Menu to highlight nodes green and display pollution history
+node_highlight_multiselect = MultiSelect(title="Pollution History",
+                                         value=["None"],
+                                         options=['None']+list(G.nodes()))
+node_highlight_multiselect.on_change('value', update_node_highlight)
 
 # Dropdown menu to highlight a node type
 node_type_dropdown = Dropdown(label="Highlight Node Type", value='None',
@@ -360,7 +359,7 @@ speed_dropdown.on_change('value', update_speed)
 # Create the layout for the graph and widgets
 layout = row(
     column(
-        node_highlight_dropdown,
+        node_highlight_multiselect,
         node_type_dropdown,
         pollution_location_dropdown,
         node_size_slider,

--- a/water/main.py
+++ b/water/main.py
@@ -225,7 +225,7 @@ def plot_bounds(locations):
 
 G, locations, all_base_demands = load_water_network()
 
-(pollution, pollution_nodes, start_node, start_step, end_step, step_size,
+(pollution, injection_nodes, start_node, start_step, end_step, step_size,
  max_pol, min_pol) = load_pollution_dynamics()
 
 # Create figure object
@@ -339,9 +339,9 @@ node_type_dropdown.on_change('value', update_node_type_highlight)
 
 # Dropdown menu to choose pollution start location
 pollution_location_dropdown = Dropdown(label="Pollution Injection Node",
-                                       value=pollution_nodes[0],
+                                       value=injection_nodes[0],
                                        css_classes=['blue_button'],
-                                       menu=pollution_nodes)
+                                       menu=injection_nodes)
 pollution_location_dropdown.on_change('value', update_injection)
 
 # Create a div to show the name of pollution start node

--- a/water/main.py
+++ b/water/main.py
@@ -9,7 +9,8 @@ from bokeh.tile_providers import get_provider, Vendors
 from bokeh.transform import log_cmap
 from collections import defaultdict
 import colorcet as cc
-from modules.html_formatter import timer_html, pollution_history_html, pollution_loaction_html
+from modules.html_formatter import (timer_html, pollution_history_html,
+                                    pollution_loaction_html)
 from modules.load_data import load_water_network, load_pollution_dynamics
 from modules.pollution import (pollution_series, pollution_history,
                                pollution_scenario)
@@ -126,7 +127,7 @@ def update_node_highlight(attrname, old, new):
     update_pollution_history()
     history_node = pollution_history_multiselect.value[0]
     pollution_history_node_div.text = pollution_history_html(history_node,
-                                                                highlight_color)
+                                                             highlight_color)
 
 
 def update_node_type_highlight(attrname, old, new):
@@ -156,7 +157,7 @@ def update_injection(attrname, old, new):
     update()
     injection_node = pollution_location_dropdown.value
     pollution_location_div.text = pollution_loaction_html(injection_node,
-                                                        injection_color)
+                                                          injection_color)
 
 
 def update_node_size(attrname, old, new):

--- a/water/main.py
+++ b/water/main.py
@@ -50,7 +50,7 @@ def update_highlights():
         })
 
     injection = pollution_location_dropdown.value
-    nodes_to_highlight = pollution_hitory_multiselect.value
+    nodes_to_highlight = pollution_history_multiselect.value
     type_highlight = node_type_dropdown.value
 
     outline_colors = []
@@ -78,7 +78,7 @@ def update_highlights():
 
 
 def update_pollution_history():
-    history = pollution_history(scenario, pollution_hitory_multiselect.value[0])
+    history = pollution_history(scenario, pollution_history_multiselect.value[0])
     pollution_history_source.data['time'] = history.index
     pollution_history_source.data['pollution_value'] = history.values
     if pollution_history_node != 'None':
@@ -125,7 +125,7 @@ def update_node_highlight(attrname, old, new):
     the update highlights function."""
     update_highlights()
     update_pollution_history()
-    pollution_hitory_node_div.text = "<p>Selection: <b style='color:" + highlight_color + "'>" + pollution_hitory_multiselect.value[0] + "</b></p>"
+    pollution_history_node_div.text = "<p>Selection: <b style='color:" + highlight_color + "'>" + pollution_history_multiselect.value[0] + "</b></p>"
 
 
 def update_node_type_highlight(attrname, old, new):
@@ -153,6 +153,7 @@ def update_injection(attrname, old, new):
     update_highlights()
     update_pollution_history()
     update()
+    pollution_location_div.text = "<p>Selection: <b style='color:" + injection_color + "'>" + pollution_location_dropdown.value + "</b></p>"
 
 
 def update_node_size(attrname, old, new):
@@ -315,13 +316,13 @@ play_button = Button(label=BUTTON_LABEL_PAUSED, button_type="success")
 play_button.on_click(animate)
 
 # Menu to highlight nodes green and display pollution history
-pollution_hitory_multiselect = MultiSelect(title="Pollution History",
+pollution_history_multiselect = MultiSelect(title="Pollution History",
                                          value=["None"],
                                          options=['None']+list(G.nodes()))
-pollution_hitory_multiselect.on_change('value', update_node_highlight)
+pollution_history_multiselect.on_change('value', update_node_highlight)
 
 # Create a div to show the name of pollution history node
-pollution_hitory_node_div = Div(text="<p>Selection: <b>None</b></p>")
+pollution_history_node_div = Div(text="<p>Selection: <b>None</b></p>")
 
 # Dropdown menu to highlight a node type
 node_type_dropdown = Dropdown(label="Highlight Node Type", value='None',
@@ -338,6 +339,9 @@ pollution_location_dropdown = Dropdown(label="Pollution Injection Node",
                                        css_classes=['blue_button'],
                                        menu=scenarios)
 pollution_location_dropdown.on_change('value', update_injection)
+
+# Create a div to show the name of pollution start node
+pollution_location_div = Div(text="<p>Selection: <b style='color:" + injection_color + "'>" + pollution_location_dropdown.value + "</b></p>")
 
 # Dropdown menu to choose node size and demand weighting
 initial_node_size = 8
@@ -363,10 +367,11 @@ timer = Div(text="")
 layout = column(
     row(
         column(
-            pollution_hitory_multiselect,
-            pollution_hitory_node_div,
+            pollution_history_multiselect,
+            pollution_history_node_div,
             node_type_dropdown,
             pollution_location_dropdown,
+            pollution_location_div,
             node_size_slider,
             play_button,
             speed_dropdown,

--- a/water/main.py
+++ b/water/main.py
@@ -321,8 +321,8 @@ play_button.on_click(animate)
 
 # Menu to highlight nodes green and display pollution history
 pollution_history_select = Select(title="Pollution History",
-                                       value="None",
-                                       options=['None']+list(G.nodes()))
+                                  value="None",
+                                  options=['None']+list(G.nodes()))
 pollution_history_select.on_change('value', update_node_highlight)
 
 # Create a div to show the name of pollution history node

--- a/water/modules/html_formatter.py
+++ b/water/modules/html_formatter.py
@@ -1,0 +1,24 @@
+import datetime
+
+
+def timer_html(timestep):
+    timer_html = "<h1 style='color:grey'>Time: "
+    timer_html += str(datetime.timedelta(seconds=int(timestep)))
+    timer_html += "</h1>"
+    return timer_html
+
+
+def pollution_history_html(history_node="None", highlight_color="black"):
+    pollution_history_html = "<p>Selection: <b style='color:"
+    pollution_history_html += highlight_color + "'>"
+    pollution_history_html += history_node
+    pollution_history_html += "</b></p>"
+    return pollution_history_html
+
+
+def pollution_loaction_html(injection_node, injection_color):
+    pollution_location_html = "<p>Selection: <b style='color:"
+    pollution_location_html += injection_color + "'>"
+    pollution_location_html += injection_node
+    pollution_location_html += "</b></p>"
+    return pollution_location_html

--- a/water/modules/load_data.py
+++ b/water/modules/load_data.py
@@ -82,10 +82,10 @@ def load_pollution_dynamics():
     # Determine max and min pollution values and all scenario names
     max_pols = []
     min_pols = []
-    scenarios = []
+    pollution_nodes = []
     for key, df in pollution.items():
         if key != 'chemical_start_time':
-            scenarios.append(key)
+            pollution_nodes.append(key)
             v = df.values.ravel()
             max_pols.append(np.max(v))
             min_pols.append(np.min(v[v > 0]))
@@ -93,10 +93,10 @@ def load_pollution_dynamics():
     min_pol = np.min(min_pols)
 
     # Choose a default node for pollution injection
-    start_node = scenarios[0]
+    start_node = pollution_nodes[0]
 
     # Determine the step numbers for the beginning and end of the pollution
-    # data. This assumes all pollution scenarios are identical in time to the
+    # data. This assumes all pollution pollution_nodes are identical in time to the
     # default starting node!
     start = pollution[start_node].index.min()
     end = pollution[start_node].index.max()
@@ -104,4 +104,4 @@ def load_pollution_dynamics():
     # Get the timstep size for the slider from the pollution df
     step = pollution[start_node].index[1] - pollution[start_node].index[0]
 
-    return pollution, scenarios, start_node, start, end, step, max_pol, min_pol
+    return pollution, pollution_nodes, start_node, start, end, step, max_pol, min_pol

--- a/water/modules/load_data.py
+++ b/water/modules/load_data.py
@@ -96,12 +96,13 @@ def load_pollution_dynamics():
     start_node = pollution_nodes[0]
 
     # Determine the step numbers for the beginning and end of the pollution
-    # data. This assumes all pollution pollution_nodes are identical in time to the
-    # default starting node!
+    # data. This assumes all pollution pollution_nodes are identical in time
+    # to the default starting node!
     start = pollution[start_node].index.min()
     end = pollution[start_node].index.max()
 
     # Get the timstep size for the slider from the pollution df
     step = pollution[start_node].index[1] - pollution[start_node].index[0]
 
-    return pollution, pollution_nodes, start_node, start, end, step, max_pol, min_pol
+    return (pollution, pollution_nodes, start_node, start, end, step,
+            max_pol, min_pol)

--- a/water/modules/load_data.py
+++ b/water/modules/load_data.py
@@ -82,10 +82,10 @@ def load_pollution_dynamics():
     # Determine max and min pollution values and all scenario names
     max_pols = []
     min_pols = []
-    pollution_nodes = []
+    injection_nodes = []
     for key, df in pollution.items():
         if key != 'chemical_start_time':
-            pollution_nodes.append(key)
+            injection_nodes.append(key)
             v = df.values.ravel()
             max_pols.append(np.max(v))
             min_pols.append(np.min(v[v > 0]))
@@ -93,10 +93,10 @@ def load_pollution_dynamics():
     min_pol = np.min(min_pols)
 
     # Choose a default node for pollution injection
-    start_node = pollution_nodes[0]
+    start_node = injection_nodes[0]
 
     # Determine the step numbers for the beginning and end of the pollution
-    # data. This assumes all pollution pollution_nodes are identical in time
+    # data. This assumes all injection_nodes are identical in time
     # to the default starting node!
     start = pollution[start_node].index.min()
     end = pollution[start_node].index.max()
@@ -104,5 +104,5 @@ def load_pollution_dynamics():
     # Get the timstep size for the slider from the pollution df
     step = pollution[start_node].index[1] - pollution[start_node].index[0]
 
-    return (pollution, pollution_nodes, start_node, start, end, step,
+    return (pollution, injection_nodes, start_node, start, end, step,
             max_pol, min_pol)


### PR DESCRIPTION
Fixes #58 
Fixes #29 

If multiple pollution histories are selected, these will be highlighted on the network but only the first selected node will be used for the the pollution history plot. Made a new issue that can expand upon this later: #68

Also gave up on implementing multi-select widget for injection node for now, created separate issue: #70 