### PR TITLE
Add option to include custom network

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,5 @@ gunicorn -w 4 main:app
 3. Open http://localhost:8000 in a browser
 
 The image is [hosted on DockerHub](https://hub.docker.com/repository/docker/turinginst/chance-water/general) and is set to build from pushes to the master branch of this repo.
+
+## [Adding custom water networks](water/data)

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -8,9 +8,22 @@ def test_get_network_examples():
     assert get_network_examples() == ['ky14', 'ky2', 'ky4', 'ky8', 'ky9']
 
 
-def test_get_custom_networks():
-    """By default, there should be no custom networks"""
-    assert get_custom_networks() == []
+if len(get_custom_networks()) > 0:
+    @pytest.mark.parametrize('network', get_custom_networks())
+    def test_get_custom_networks(network):
+        """By default, there should be no custom networks. If there are, check
+        that there is a pollution file present for every node in the network,
+        with the exception of tanks and reservoirs"""
+        _, injection_nodes, *_ = load_pollution_dynamics(network)
+        networkx_graph, *_ = load_water_network(network)
+        graph_nodes = []
+        for node in networkx_graph.nodes():
+            type = networkx_graph.nodes[node]['type']
+            if type != 'Tank' and type != 'Reservoir':
+                graph_nodes.append(node)
+        injection_nodes.sort()
+        graph_nodes.sort()
+        assert injection_nodes == graph_nodes
 
 
 def test_get_network_files_path_bad_network():

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -1,0 +1,11 @@
+import pytest
+from water.modules.load_data import get_network_examples, get_custom_networks
+
+
+def test_get_network_examples():
+    assert get_network_examples() == ['ky14', 'ky2', 'ky4', 'ky8', 'ky9']
+
+
+def test_get_custom_networks():
+    """By default, there should be no custom networks"""
+    assert get_custom_networks() == []

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -1,5 +1,6 @@
 import pytest
-from water.modules.load_data import get_network_examples, get_custom_networks
+from water.modules.load_data import (get_network_examples, get_custom_networks,
+                                     get_network_files_path)
 
 
 def test_get_network_examples():
@@ -9,3 +10,14 @@ def test_get_network_examples():
 def test_get_custom_networks():
     """By default, there should be no custom networks"""
     assert get_custom_networks() == []
+
+
+def test_get_network_files_path_bad_network():
+    """Check exception raised for bad network name"""
+    with pytest.raises(Exception):
+        get_network_files_path('bad network name')
+
+
+def test_get_network_files_path_ky2_example_network():
+    """Check path created for known example"""
+    assert 'data/examples/ky2' in get_network_files_path('ky2')

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -8,24 +8,6 @@ def test_get_network_examples():
     assert get_network_examples() == ['ky14', 'ky2', 'ky4', 'ky8', 'ky9']
 
 
-if len(get_custom_networks()) > 0:
-    @pytest.mark.parametrize('network', get_custom_networks())
-    def test_get_custom_networks(network):
-        """By default, there should be no custom networks. If there are, check
-        that there is a pollution file present for every node in the network,
-        with the exception of tanks and reservoirs"""
-        _, injection_nodes, *_ = load_pollution_dynamics(network)
-        networkx_graph, *_ = load_water_network(network)
-        graph_nodes = []
-        for node in networkx_graph.nodes():
-            type = networkx_graph.nodes[node]['type']
-            if type != 'Tank' and type != 'Reservoir':
-                graph_nodes.append(node)
-        injection_nodes.sort()
-        graph_nodes.sort()
-        assert injection_nodes == graph_nodes
-
-
 def test_get_network_files_path_bad_network():
     """Check exception raised for bad network name"""
     with pytest.raises(Exception):

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -1,6 +1,7 @@
 import pytest
 from water.modules.load_data import (get_network_examples, get_custom_networks,
-                                     get_network_files_path)
+                                     get_network_files_path, load_water_network,
+                                     load_pollution_dynamics)
 
 
 def test_get_network_examples():
@@ -21,3 +22,17 @@ def test_get_network_files_path_bad_network():
 def test_get_network_files_path_ky2_example_network():
     """Check path created for known example"""
     assert 'data/examples/ky2' in get_network_files_path('ky2')
+
+
+def test_load_water_network_bad_network():
+    """Check that the error raised by providing a bad network name to
+    get_network_files_path() also stops load_water_network()"""
+    with pytest.raises(Exception):
+        load_water_network('bad network name')
+
+
+def test_load_pollution_dynamics_bad_network():
+    """Check that the error raised by providing a bad network name to
+    get_network_files_path() also stops load_pollution_dynamics()"""
+    with pytest.raises(Exception):
+        load_pollution_dynamics('bad network name')

--- a/water/data/README.md
+++ b/water/data/README.md
@@ -1,0 +1,40 @@
+Water network data
+=======
+
+The examples directory contains a set of example water networks with pollution scenarios produced by simulation with [WNTR](https://github.com/USEPA/WNTR).
+
+The example networks are taken from the [Water Distribution System Research Database](http://www.uky.edu/WDST/database.html) and use the same naming convention.
+
+Loading new networks and pollution data
+-------
+
+You can follow these modified instructions to load a custom water network with pollution timeseries node data similar to the examples.
+
+1. Clone the repository: `git clone https://github.com/alan-turing-institute/chance-water-distribution`
+2. Install the python requirements: `pip install -r requirements.txt`
+3. If you want to include the example networks, download the data modules: `git submodule update --init --recursive`
+4. **Include a new subdirectory within `chance-water-distribution/water/data` with the files specified below (e.g. called custom_network)**
+5. Run flask server from top dir of the repo: `python water/main.py`
+6. Open http://localhost:8000 in a browser
+
+### Custom network directory structure
+
+The directory structure must follow those of the examples which is as follows:
+
+```
+custom_network
+│   custom_network.inp
+|   metadata.yml
+│
+└───custom_network
+│   │   J-1.pkl
+│   │   J-2.pkl
+|   |   ...
+
+```
+
+The `.inp` file is an [EPANET INP file, used by the wntr python package to build a water network model](https://wntr.readthedocs.io/en/latest/waternetworkmodel.html).
+
+For each node in the network that you want to show pollution spread starting from, add a pollution file with a simulation of pollution spread from that node. The file should be a pickle of a pandas dataframe containing pollution concentration for each node at each timestep for a 24hr period.
+
+You can add multiple subdirectories to `water/data` if you have more than one network to display. They can be switched between with the "Network" widget in the top left corner of the flask/bokeh app.

--- a/water/data/README.md
+++ b/water/data/README.md
@@ -33,8 +33,8 @@ custom_network
 
 ```
 
-The `.inp` file is an [EPANET INP file, used by the wntr python package to build a water network model](https://wntr.readthedocs.io/en/latest/waternetworkmodel.html).
-
-For each node in the network that you want to show pollution spread starting from, add a pollution file with a simulation of pollution spread from that node. The file should be a pickle of a pandas dataframe containing pollution concentration for each node at each timestep for a 24hr period.
+1. The `.inp` file is an [EPANET INP file, used by the wntr python package to build a water network model](https://wntr.readthedocs.io/en/latest/waternetworkmodel.html).
+2. For each node in the network that you want to show pollution spread starting from, add a pollution file with a simulation of pollution spread from that node. The file should be a `.pkl` of a pandas dataframe containing pollution concentration for each node at each timestep for a 24hr period.
+3. *Optionally* add a file called `metadata.yml`. This should contain offset values for the graph network node coordinates that convert these to the actual latitude and longitude (see the example `ky2`). When this is included, the network is placed over a map.
 
 You can add multiple subdirectories to `water/data` if you have more than one network to display. They can be switched between with the "Network" widget in the top left corner of the flask/bokeh app.

--- a/water/main.py
+++ b/water/main.py
@@ -21,7 +21,7 @@ from flask import Flask, render_template, request
 from modules.html_formatter import (timer_html, pollution_history_html,
                                     pollution_location_html, node_type_html)
 from modules.load_data import (load_water_network, load_pollution_dynamics,
-                               get_networks)
+                               get_networks, get_custom_networks)
 from modules.pollution import (pollution_series, pollution_history,
                                pollution_scenario)
 from threading import Thread
@@ -50,6 +50,14 @@ def bkapp(doc):
 
     # Color of selected node type
     type_highlight_color = "purple"
+
+    # By default, we want example network ky2 to load into the bokeh app
+    # If however any custom networks are present, that a user has added
+    # make one of these the default selected network
+    default_network = 'ky2'
+    custom_networks = get_custom_networks()
+    if len(custom_networks) > 0:
+        default_network = custom_networks[0]
 
     def update_highlights():
         """Set the color and width for each node and edge in the graph."""
@@ -297,10 +305,10 @@ def bkapp(doc):
         network = args.get('network')[0].decode('utf8')
         if network not in networks:
             # If an invalid network is selected fall back to the default
-            network = networks[0]
+            network = default_network
     else:
         # If there is no request fall back to the deault
-        network = networks[0]
+        network = default_network
 
     G, locations, all_base_demands, include_map = load_water_network(network)
 

--- a/water/main.py
+++ b/water/main.py
@@ -21,7 +21,7 @@ from flask import Flask, render_template, request
 from modules.html_formatter import (timer_html, pollution_history_html,
                                     pollution_location_html, node_type_html)
 from modules.load_data import (load_water_network, load_pollution_dynamics,
-                               get_network_examples)
+                               get_networks)
 from modules.pollution import (pollution_series, pollution_history,
                                pollution_scenario)
 from threading import Thread
@@ -289,7 +289,7 @@ def bkapp(doc):
         return Range1d(x_lower, x_upper), Range1d(y_lower, y_upper)
 
     # Load the network dirnames
-    networks = get_network_examples()
+    networks = get_networks()
 
     # Get network from request
     args = doc.session_context.request.arguments
@@ -297,10 +297,10 @@ def bkapp(doc):
         network = args.get('network')[0].decode('utf8')
         if network not in networks:
             # If an invalid network is selected fall back to the default
-            network = networks[1]
+            network = networks[0]
     else:
         # If there is no request fall back to the deault
-        network = networks[1]
+        network = networks[0]
 
     G, locations, all_base_demands, include_map = load_water_network(network)
 
@@ -536,7 +536,7 @@ sockets, port = bind_sockets("127.0.0.1", 0)
 @app.route('/', methods=['GET'])
 def bkapp_page():
     # Get network names, used in template
-    network_names = get_network_examples()
+    network_names = get_networks()
 
     # Get Network request argument
     current_network_name = request.args.get('network_name')

--- a/water/modules/load_data.py
+++ b/water/modules/load_data.py
@@ -55,8 +55,10 @@ def load_water_network(network):
     filename = file_path + '/' + network + '.inp'
 
     # Create water network
-    # try:
-    wn = wntr.network.WaterNetworkModel(filename)
+    try:
+        wn = wntr.network.WaterNetworkModel(filename)
+    except FileNotFoundError:
+        raise FileNotFoundError("Please add the water network file: " + filename)
 
     # Get the NetworkX graph
     G = wn.get_graph().to_undirected()

--- a/water/modules/load_data.py
+++ b/water/modules/load_data.py
@@ -8,6 +8,8 @@ import yaml
 
 
 def get_network_examples():
+    """Get the names of example water networks with data files present
+    in water/data/examples as a list of strings"""
     examples = []
     dir = join(dirname(__file__), '../data',
                'examples/')
@@ -16,6 +18,17 @@ def get_network_examples():
             examples.append(filename)
     examples.sort()
     return examples
+
+
+def get_custom_networks():
+    """Get the names of any non-example water networks added to water/data
+    as a list of strings"""
+    custom_networks = []
+    dir = join(dirname(__file__), '../data')
+    for filename in listdir(dir):
+        if isdir(join(dir, filename)) and filename != 'examples':
+            custom_networks.append(filename)
+    return custom_networks
 
 
 def load_water_network(network):

--- a/water/modules/load_data.py
+++ b/water/modules/load_data.py
@@ -44,8 +44,7 @@ def load_water_network(network):
             G.nodes[node]['elevation'] = 'N/A'
         try:
             base_demands = []
-            # TODO: For some reason this is a list, but in Kentucky 2
-            # data there is only ever a single base demand value
+            # Base demand value used to weight node size
             for timeseries in wn.get_node(node).demand_timeseries_list:
                 base_demands.append(timeseries.base_value)
             base_demand = mean(base_demands)

--- a/water/modules/load_data.py
+++ b/water/modules/load_data.py
@@ -38,10 +38,10 @@ def get_networks():
 def get_network_files_path(network):
     if network in get_network_examples():
         return join(dirname(__file__), '../data',
-                        'examples/' + network)
+                    'examples/' + network)
     elif network in get_custom_networks():
         return join(dirname(__file__), '../data',
-                        network)
+                    network)
     else:
         raise ValueError('Selected network cannot be loaded, files missing')
 
@@ -58,7 +58,8 @@ def load_water_network(network):
     try:
         wn = wntr.network.WaterNetworkModel(filename)
     except FileNotFoundError:
-        raise FileNotFoundError("Please add the water network file: " + filename)
+        raise FileNotFoundError("Please add the water network file: " +
+                                filename)
 
     # Get the NetworkX graph
     G = wn.get_graph().to_undirected()

--- a/water/modules/load_data.py
+++ b/water/modules/load_data.py
@@ -31,12 +31,31 @@ def get_custom_networks():
     return custom_networks
 
 
+def get_networks():
+    return get_custom_networks() + get_network_examples()
+
+
+def get_network_files_path(network):
+    if network in get_network_examples():
+        return join(dirname(__file__), '../data',
+                        'examples/' + network)
+    elif network in get_custom_networks():
+        return join(dirname(__file__), '../data',
+                        network)
+    else:
+        raise ValueError('Selected network cannot be loaded, files missing')
+
+
 def load_water_network(network):
+    """Get data variables needed for the visualisation from the water network
+    .inp file"""
+
     # load .inp file
-    filename = join(dirname(__file__), '../data',
-                    'examples/' + network + '/' + network + '.inp')
+    file_path = get_network_files_path(network)
+    filename = file_path + '/' + network + '.inp'
 
     # Create water network
+    # try:
     wn = wntr.network.WaterNetworkModel(filename)
 
     # Get the NetworkX graph
@@ -91,9 +110,7 @@ def load_water_network(network):
     y_offset = 0
     include_map = False
     try:
-        metadata_file = join(dirname(__file__), '../data', 'examples/'
-                                                + network
-                                                + '/metadata.yml')
+        metadata_file = file_path + '/metadata.yml'
         with open(metadata_file, 'r') as stream:
             metadata = yaml.safe_load(stream)
             if 'map' in metadata:
@@ -115,8 +132,8 @@ def load_water_network(network):
 def load_pollution_dynamics(network):
     # Load pollution dynamics
     # Create pollution as a global var used in some functions
-    files = join(dirname(__file__), '../data',
-                 'examples/' + network + '/' + network + '')
+
+    files = get_network_files_path(network) + '/' + network
     # Determine max and min pollution values and all node names
     max_pols = []
     min_pols = []

--- a/water/modules/pollution.py
+++ b/water/modules/pollution.py
@@ -69,4 +69,8 @@ def pollution_scenario(pollution, injection):
             timessteps. The columns of the dataframe are the node labels and
             the index is a set of timesteps.
     """
-    return pollution[injection]
+    try:
+        return pollution[injection]
+    except KeyError:
+        error = "Can't find .pkl file for pollution injection at " + injection
+        raise KeyError(error)


### PR DESCRIPTION
Closes #27 
@JimMadge please could I get you to test this feature as follows (just as a sanity check it works on your machine and the instructions make sense):

1. Create a duplicate of one of the example networks (perhaps copy ky2 and modify the metadata.yml so it's easy to identify when your copy is loaded rather than the original)
2. Rename this duplicate and then as per the README instructions add it back to `water/data`
3. Check that the new network loads when you run the app locally

Since I think the only person likely to ever use this feature will be Alessio's replacement, I'm not sure that adding an upload widget is worth the effort rather than simply instructing to copy in the new data dir in manually as I have done here - it wouldn't save any time when running the app locally, since you have to clone the repo to do that anyway.

I might however investigate using docker volumes, so that with the docker version you could just run the container with the extra data dir (even then, not sure how much time this is saving).

@JimMadge what do you think?