### PR TITLE
Get docker working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ RUN pip install -r requirements.txt
 RUN pip install gunicorn
 
 WORKDIR /water
-CMD gunicorn -w 4 main:app
+EXPOSE 8000
+CMD ["gunicorn", "-b", "0.0.0.0:8000", "-w", "4", "main:app"]

--- a/water/main.py
+++ b/water/main.py
@@ -538,7 +538,7 @@ bkapp = Application(FunctionHandler(bkapp))
 
 # This is so that if this app is run using something like "gunicorn -w 4" then
 # each process will listen on its own port
-sockets, port = bind_sockets("127.0.0.1", 0)
+sockets, port = bind_sockets("0.0.0.0", 0)
 
 
 @app.route('/', methods=['GET'])
@@ -562,7 +562,7 @@ def bk_worker():
 
     bokeh_tornado = BokehTornado(
         {'/bkapp': bkapp},
-        extra_websocket_origins=["localhost:8000"]
+        extra_websocket_origins=["localhost:80"]
         )
     bokeh_http = HTTPServer(bokeh_tornado)
     bokeh_http.add_sockets(sockets)
@@ -575,4 +575,4 @@ def bk_worker():
 Thread(target=bk_worker).start()
 
 if __name__ == '__main__':
-    app.run(port=8000)
+    app.run(host="0.0.0.0", port=80)


### PR DESCRIPTION
@JimMadge I've tried to copy what's happening in [this blog](https://medium.com/@kmmanoj/deploying-a-scalable-flask-app-using-gunicorn-and-nginx-in-docker-part-1-3344f13c9649) .

I managed to get the app working with `gunicorn -b 0.0.0.0:80 -w 4 main:app` and going to localhost:80 in browser.

After building the image and attempting to run a container (e.g. `docker run -p 80:8000 turinginst/chance-water`), then going to localhost:80 I get an error from flask running in the container that ends: `jinja2.exceptions.TemplateNotFound: embed.html` - I guess what we're doing here is a bit more complicated than the one in the blog post, but might be a simple fix? Not sure